### PR TITLE
Jekyll 테스트 환경 구축

### DIFF
--- a/Jekyll/Dockerfile
+++ b/Jekyll/Dockerfile
@@ -1,16 +1,17 @@
-FROM ruby:alpine3.14
+FROM ruby:2.7-alpine
 
 # preinstall for jekyll
 RUN apk update \
 &&  apk add --no-cache \
 	gcc \
 	g++ \
+	git \
 	make \
 	musl-dev \
 	vim
 
 # install jekyll & bundle
-RUN gem install jekyll bundle
+RUN gem install jekyll bundler
 
 EXPOSE	4000
 

--- a/Jekyll/Dockerfile
+++ b/Jekyll/Dockerfile
@@ -1,0 +1,17 @@
+FROM ruby:alpine3.14
+
+# preinstall for jekyll
+RUN apk update \
+&&  apk add --no-cache \
+	gcc \
+	g++ \
+	make \
+	musl-dev \
+	vim
+
+# install jekyll & bundle
+RUN gem install jekyll bundle
+
+EXPOSE	4000
+
+CMD [ "/bin/ash" ]

--- a/Jekyll/build.sh
+++ b/Jekyll/build.sh
@@ -1,0 +1,1 @@
+docker build -t jekyll .

--- a/Jekyll/run.sh
+++ b/Jekyll/run.sh
@@ -1,0 +1,1 @@
+docker run -it -d --name blog -p 127.0.0.1:4000:4000 jekyll


### PR DESCRIPTION
# Jekyll 테스트 환경 구축

## **종류**
### **격리 방법**
- [x] container
### **개발 툴**
- [x] github-page
### **격리환경에 설치된 것**
- [x] ruby2.7
- [x] Jekyll
- [x] bundler

## 내용
- github-page에서 이용하려면 ruby2.7 버전을 이용해야한다는것을 학습
- alpine 컨테이너의 경우 libc가 설치되어있지 않음, libc에 다양한 버전이 있는것을 확인.
- Gemfile에 githubpage의 의존성을 기입해 설치하는것에 대해 학습

## 연관된 이슈
close #4 